### PR TITLE
Fix test to match multiple spaces

### DIFF
--- a/t/unrtf.t
+++ b/t/unrtf.t
@@ -17,7 +17,7 @@ sub test_object : Tests {
 
 sub convert_rtf_file_to_text : Tests {
   my $object = UnRTF->new(file => 't/samples/sample.rtf');
-  like($object->convert(format => 'text'), qr/# Translation from RTF performed by UnRTF/);
+  like($object->convert(format => 'text'), qr/#\s+Translation from RTF performed by UnRTF/);
 }
 
 sub convert_to_blank_if_dont_tell_format : Tests {


### PR DESCRIPTION
This fixes the test for

```
$ unrtf --version
0.21.10
```

which outputs

```
###  Translation from RTF performed by UnRTF, version 0.21.10
```
